### PR TITLE
Fix autobuild for organization

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,8 +66,8 @@ jobs:
         run: dotnet pack --no-restore --version-suffix build.${{ github.run_number }}.${{ github.run_attempt }} -o "nugets" -p:FullTargets=true
 
       - name: Publish
-        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-        run: dotnet nuget push ./nugets/*nupkg --source https://nuget.pkg.github.com/yungd1plomat/index.json --skip-duplicate --api-key ${{ secrets.NUGET_KEY }}
+        #if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+        run: dotnet nuget push ./nugets/*nupkg --source https://nuget.pkg.github.com/SharpAdb/index.json --skip-duplicate --api-key ${{ secrets.NUGET_KEY }}
 
       - name: Upload
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,7 +66,7 @@ jobs:
         run: dotnet pack --no-restore --version-suffix build.${{ github.run_number }}.${{ github.run_attempt }} -o "nugets" -p:FullTargets=true
 
       - name: Publish
-        #if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         run: dotnet nuget push ./nugets/*nupkg --source https://nuget.pkg.github.com/SharpAdb/index.json --skip-duplicate --api-key ${{ secrets.NUGET_KEY }}
 
       - name: Upload


### PR DESCRIPTION
After moving the repository to a separate organization, packages need to be published in the same organization packages