### PR TITLE
Create better documentation

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,0 +1,25 @@
+- **About**
+    - [Introduction](introduction)
+    - [Consulting and Support](support)
+    - [Licence](licence)
+- **Getting started**
+    - [Installation](installation)
+    - [Connecting to device](connecting)
+    - [Working with lib](working)
+- **Reference**
+    - Screen automation
+        - [Find elements]()
+        - [Click on an element]()
+        - [Swipe]()
+        - [Type text]()
+        - [Send key events]()
+        - [Dump xml hierarchy]()
+        - [Create screenshots]()
+    - Device commands
+        - [Install applications]()
+        - [Starting applications]()
+        - [Working with files]()
+        - [Run shell commands]()
+        - [Forward connection]()
+- **Tutorials**
+    - [Automate multiple Nox emulators]()

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -1,0 +1,84 @@
+# Connecting to device
+
+## Running the adb server
+AdvancedSharpAdbClient does not communicate directly with your Android devices, but uses the `adb.exe` server process as an intermediate. Before you can connect to your Android device, you must first start the `adb.exe` server.
+
+To specify the path to adb and start the server use:
+```csharp
+StartServerResult startServerResult = await AdbServer.Instance.StartServerAsync("platform-tools\\adb.exe", false, CancellationToken.None);
+```
+If you started the server manually, no action is required
+
+## Connecting to an emulator
+If you are using an emulator, you need to know the ip and port to connect. Example for [Nox emulator](https://en.bignox.com/) it is `127.0.0.1:62001`
+```csharp
+var client = new AdbClient();
+await client.ConnectAsync("127.0.0.1", 62001);
+```
+
+## Connecting to a real device via a USB cable
+If you are using a real device, you need to enable `USB debugging` in the developer settings. Then you need to connect the device via cable and enable debugging on the phone. The device will automatically connect to ADB.
+```csharp
+var client = new AdbClient();
+var devices = await client.GetDevicesAsync();
+foreach (var device in devices)
+{
+    Console.WriteLine(device.Name);
+}
+```
+
+## Connecting to a real device via wifi
+Go to developer settings, select `Wifi debugging` and choose `Connect With Pairing Code`. Then you can pair your device like this
+```csharp
+var client = new AdbClient();
+Console.Write("Enter pair host (like 127.0.0.1:1234): ");
+var host = Console.ReadLine();
+Console.Write("Enter pair code: ");
+var pairCode = Console.ReadLine();
+var result = await client.PairAsync(host, pairCode);
+Console.WriteLine(result);
+Console.Write("Enter connect host (like 127.0.0.1:4321): ");
+var connectEndpoint = Console.ReadLine();
+var connectHost = connectEndpoint.Split(":")[0];
+var connectPort = int.Parse(connectEndpoint.Split(":")[1]);
+await client.ConnectAsync(connectHost, connectPort);
+```
+
+> Please note that the connect IP and pair IP are usually the same, but the connect port and pair port are different.
+
+## Events
+You can also use the library to detect when the device is connecting, disconnecting, or changing.
+```csharp
+await using DeviceMonitor deviceMonitor = new(new AdbSocket(new IPEndPoint(IPAddress.Loopback, AdbClient.AdbServerPort)));
+deviceMonitor.DeviceConnected += (sender, e) => Trace.WriteLine($"Device connected: {e.Device}");
+deviceMonitor.DeviceDisconnected += (sender, e) => Trace.WriteLine($"Device disconnected: {e.Device}");
+deviceMonitor.DeviceChanged += (sender, e) => Trace.WriteLine($"Device state changed: {e.Device} {e.OldState} -> {e.NewState}");
+await deviceMonitor.StartAsync();
+```
+
+`DeviceMonitor` returns `DeviceData` that doesn't have a device model and name, and also can't be used for device automation. To obtain a `Device` that can be used further use the following code
+```csharp
+var client = new AdbClient();
+await using DeviceMonitor deviceMonitor = new(new AdbSocket(new IPEndPoint(IPAddress.Loopback, AdbClient.AdbServerPort)));
+deviceMonitor.DeviceConnected += async (s, deviceData) =>
+{
+    var devices = await client.GetDevicesAsync();
+    var device = devices.First(d => d.Serial == deviceData.Device.Serial);
+    Trace.WriteLine($"Device connected: {device.Model}");
+};
+await deviceMonitor.StartAsync();
+```
+
+Or you can directly monitor when device connected like this
+```csharp
+var client = new AdbClient();
+var devices = await client.GetDevicesAsync();
+while (!devices.Any(x => x.State == DeviceState.Online)) 
+{
+    Trace.WriteLine("Waiting for device connection..");
+    devices = await client.GetDevicesAsync();
+    await Task.Delay(1000);
+}
+var device = devices.FirstOrDefault();
+Trace.WriteLine($"Connected {device.Name}");
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,32 @@
+# Getting started
+
+## Installation
+### From nuget package manager
+To install AdvancedSharpAdbClient install the [AdvancedSharpAdbClient NuGetPackage](https://www.nuget.org/packages/AdvancedSharpAdbClient). 
+If you're using Visual Studio, you can run the following command in the [Package Manager Console](http://docs.nuget.org/consume/package-manager-console):
+```powershell
+PM> Install-Package AdvancedSharpAdbClient
+```
+### From main branch
+You can install the actual version which is in the [main](https://github.com/SharpAdb/AdvancedSharpAdbClient) branch.
+If you're using Visual Studio, you can run the following command in the [Package Manager Console](http://docs.nuget.org/consume/package-manager-console):
+```powershell
+PM> Install-Package AdvancedSharpAdbClient -Source https://nuget.pkg.github.com/SharpAdb/index.json
+```
+Then enter your github credentials and click OK.
+
+!> This is a beta version and may contain bugs. Use it only to test new features and fixes before release.
+
+## Connecting to device
+### Running adb server
+To specify the path to adb and start the server use:
+```csharp
+StartServerResult startServerResult = await AdbServer.Instance.StartServerAsync("platform-tools\\adb.exe", false, CancellationToken.None);
+```
+This will return one of these statuses:
+```csharp
+StartServerResult.Started
+StartServerResult.AlreadyRunning
+StartServerResult.RestartedOutdatedDaemon
+```
+If you started the server manually, no action is required

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>AdvancedSharpAdbClient</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css" title="docsify-darklight-theme" type="text/css"/>
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      loadSidebar: true,
+      name: 'AdvancedSharpAdbClient',
+      homepage: 'introduction.md',
+      auto2top: true,
+      search: {
+        depth: 3,
+        noData: 'No results!',
+        placeholder: 'Search...'
+      },
+      darklightTheme: {
+        defaultTheme : 'dark',
+      }
+    }
+  </script>
+  
+  <!-- Docsify v4 -->
+  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-csharp.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-powershell.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify-pagination@2/dist/docsify-pagination.min.js"></script>
+</body>
+</html>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,16 @@
+# Installation
+## From nuget package manager
+To install AdvancedSharpAdbClient install the [AdvancedSharpAdbClient NuGetPackage](https://www.nuget.org/packages/AdvancedSharpAdbClient). 
+If you're using Visual Studio, you can run the following command in the [Package Manager Console](http://docs.nuget.org/consume/package-manager-console):
+```powershell
+PM> Install-Package AdvancedSharpAdbClient
+```
+## From main branch
+You can install the actual version which is in the [main](https://github.com/SharpAdb/AdvancedSharpAdbClient) branch.
+If you're using Visual Studio, you can run the following command in the [Package Manager Console](http://docs.nuget.org/consume/package-manager-console):
+```powershell
+PM> Install-Package AdvancedSharpAdbClient -Source https://nuget.pkg.github.com/SharpAdb/index.json
+```
+Then enter your github credentials and click OK.
+
+!> This is a beta version and may contain bugs. Use it only to test new features and fixes before release.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,23 @@
+# Introduction
+
+## A .NET client for adb, the Android Debug Bridge (AdvancedSharpAdbClient)
+
+AdvancedSharpAdbClient is a .NET library that allows .NET applications to communicate with Android devices. It provides a .NET implementation of the adb protocol, giving more flexibility to the developer than launching an adb.exe process and parsing the console output.
+
+> It's upgraded version of [SharpAdbClient](https://github.com/quamotion/madb). Added important features.
+
+## Support Platform
+- .NET Framework 2.0 (Without Task)
+- .NET Framework 3.5
+- .NET Framework 4.0 (Need [Microsoft.Bcl.Async](https://www.nuget.org/packages/Microsoft.Bcl.Async))
+- .NET Framework 4.5.2
+- .NET Framework 4.6.2
+- .NET Framework 4.8.1
+- .NET Standard 1.3
+- .NET Standard 2.0
+- .NET Standard 2.1
+- .NET Core 5.0 (Support UAP 10.0 and UAP 10.0.15138.0)
+- .NET Core App 2.1
+- .NET Core App 3.1
+- .NET 6.0
+- .NET 8.0

--- a/docs/licence.md
+++ b/docs/licence.md
@@ -1,0 +1,10 @@
+# Licence
+
+## History
+AdvancedSharpAdbClient is a fork of [SharpAdbClient](https://github.com/quamotion/madb) and [madb](https://github.com/camalot/madb) which in itself is a .NET port of the [ddmlib Java Library](https://android.googlesource.com/platform/tools/base/+/master/ddmlib/).
+
+## Credits:
+https://github.com/camalot, https://github.com/quamotion
+
+## Licence
+This project is licensed under the Apache license. See the [LICENSE](https://raw.githubusercontent.com/SharpAdb/AdvancedSharpAdbClient/main/LICENSE) file for more details.

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,7 @@
+# Consulting and Support
+
+## Suggestions and problems
+Please open an [issue](https://github.com/SharpAdb/AdvancedSharpAdbClient/issues) on if you have suggestions or problems.
+
+## Contributors
+[![Contributors](https://contrib.rocks/image?repo=SharpAdb/AdvancedSharpAdbClient)](https://github.com/SharpAdb/AdvancedSharpAdbClient/graphs/contributors)

--- a/docs/working.md
+++ b/docs/working.md
@@ -1,0 +1,27 @@
+# Working with lib
+
+## Working with single device
+For each executed command with AdvancedSharpAdbClient, you need to specify for which device it should be performed. You can obtain the necessary device from the following code
+```csharp
+var client = new AdbClient();
+var devices = await client.GetDevicesAsync();
+var device = devices.FirstOrDefault();
+```
+
+Next, you can use this device to execute commands, for example, to capture a screenshot
+```csharp
+var frameBuffer = await client.GetFrameBufferAsync(device);
+var screenshot = frameBuffer.ToImage();
+```
+
+## Working with multiple devices
+Working with multiple devices is no different from working with a single device. You just need to connect to all devices and send commands to each device one by one.
+```csharp
+var client = new AdbClient();
+var devices = await client.GetDevicesAsync();
+foreach (var device in devices)
+{
+    var frameBuffer = await client.GetFrameBufferAsync(device);
+    var screenshot = frameBuffer.ToImage();
+}
+```


### PR DESCRIPTION
Sections:
- **About**
    - [x] Introduction
    - [x] Consulting and Support
    - [x] Licence
- **Getting started**
    - [x] Installation
    - [x] Connecting to device
    - [x] Working with lib
- **Reference**
    - Screen automation
        - [ ] Find elements
        - [ ] Click on an element
        - [ ] Swipe
        - [ ] Type text
        - [ ] Send key events
        - [ ] Dump xml hierarchy
        - [ ] Create screenshots
    - Device commands
        - [ ] Install applications
        - [ ] Starting applications
        - [ ] Working with files
        - [ ] Run shell commands
        - [ ] Forward connection
- **Tutorials**
    - [ ] Automate multiple Nox emulators
    

Docs created using [docsify](https://docsify.js.org) and [docsify-darklight-theme](https://docsify-darklight-theme.boopathikumar.me/)

To serve docs use docsify http server
```
# Install docsify
npm i docsify-cli -g

# Serve docs
docsify serve docs
```

Or using any other http servers. Example with python:
```Python
cd docs && python -m SimpleHTTPServer 3000

# OR

cd docs && python -m http.server 3000
```