### PR TITLE
When connecting devices, prioritize the use of transport_id

### DIFF
--- a/AdvancedSharpAdbClient.Tests/Dummys/DummyAdbSocket.cs
+++ b/AdvancedSharpAdbClient.Tests/Dummys/DummyAdbSocket.cs
@@ -146,10 +146,14 @@ namespace AdvancedSharpAdbClient.Tests
             // to a specific device
             if (device != null)
             {
-                if(!string.IsNullOrWhiteSpace(device.TransportId) && uint.TryParse(device.TransportId,out var tid))
+                if (uint.TryParse(device.TransportId, out uint tid))
+                {
                     SendAdbRequest($"host:transport-id:{tid}");
+                }
                 else
+                {
                     SendAdbRequest($"host:transport:{device.Serial}");
+                }
 
                 try
                 {

--- a/AdvancedSharpAdbClient.Tests/Dummys/DummyAdbSocket.cs
+++ b/AdvancedSharpAdbClient.Tests/Dummys/DummyAdbSocket.cs
@@ -146,7 +146,10 @@ namespace AdvancedSharpAdbClient.Tests
             // to a specific device
             if (device != null)
             {
-                SendAdbRequest($"host:transport:{device.Serial}");
+                if(!string.IsNullOrWhiteSpace(device.TransportId) && uint.TryParse(device.TransportId,out var tid))
+                    SendAdbRequest($"host:transport-id:{tid}");
+                else
+                    SendAdbRequest($"host:transport:{device.Serial}");
 
                 try
                 {

--- a/AdvancedSharpAdbClient/AdbSocket.Async.cs
+++ b/AdvancedSharpAdbClient/AdbSocket.Async.cs
@@ -262,7 +262,10 @@ namespace AdvancedSharpAdbClient
             // to a specific device
             if (device != null)
             {
-                await SendAdbRequestAsync($"host:transport:{device.Serial}", cancellationToken).ConfigureAwait(false);
+                if(!string.IsNullOrWhiteSpace(device.TransportId) && uint.TryParse(device.TransportId,out var tid))
+                    await SendAdbRequestAsync($"host:transport-id:{tid}", cancellationToken).ConfigureAwait(false);
+                else
+                    await SendAdbRequestAsync($"host:transport:{device.Serial}", cancellationToken).ConfigureAwait(false);                
 
                 try
                 {

--- a/AdvancedSharpAdbClient/AdbSocket.Async.cs
+++ b/AdvancedSharpAdbClient/AdbSocket.Async.cs
@@ -262,10 +262,9 @@ namespace AdvancedSharpAdbClient
             // to a specific device
             if (device != null)
             {
-                if(!string.IsNullOrWhiteSpace(device.TransportId) && uint.TryParse(device.TransportId,out var tid))
-                    await SendAdbRequestAsync($"host:transport-id:{tid}", cancellationToken).ConfigureAwait(false);
-                else
-                    await SendAdbRequestAsync($"host:transport:{device.Serial}", cancellationToken).ConfigureAwait(false);                
+                await (uint.TryParse(device.TransportId, out uint tid)
+                    ? SendAdbRequestAsync($"host:transport-id:{tid}", cancellationToken).ConfigureAwait(false)
+                    : SendAdbRequestAsync($"host:transport:{device.Serial}", cancellationToken).ConfigureAwait(false));
 
                 try
                 {

--- a/AdvancedSharpAdbClient/AdbSocket.cs
+++ b/AdvancedSharpAdbClient/AdbSocket.cs
@@ -401,7 +401,10 @@ namespace AdvancedSharpAdbClient
             // to a specific device
             if (device != null)
             {
-                SendAdbRequest($"host:transport:{device.Serial}");
+                if(!string.IsNullOrWhiteSpace(device.TransportId) && uint.TryParse(device.TransportId,out var tid))
+                    SendAdbRequest($"host:transport-id:{tid}");
+                else
+                    SendAdbRequest($"host:transport:{device.Serial}");
 
                 try
                 {

--- a/AdvancedSharpAdbClient/AdbSocket.cs
+++ b/AdvancedSharpAdbClient/AdbSocket.cs
@@ -401,10 +401,14 @@ namespace AdvancedSharpAdbClient
             // to a specific device
             if (device != null)
             {
-                if(!string.IsNullOrWhiteSpace(device.TransportId) && uint.TryParse(device.TransportId,out var tid))
+                if (uint.TryParse(device.TransportId, out uint tid))
+                {
                     SendAdbRequest($"host:transport-id:{tid}");
+                }
                 else
+                {
                     SendAdbRequest($"host:transport:{device.Serial}");
+                }
 
                 try
                 {

--- a/AdvancedSharpAdbClient/Models/DeviceData.cs
+++ b/AdvancedSharpAdbClient/Models/DeviceData.cs
@@ -107,7 +107,7 @@ namespace AdvancedSharpAdbClient.Models
         /// <summary>
         /// <see langword="false"/> if <see cref="DeviceData"/> does not have a valid serial number; otherwise, <see langword="true"/>.
         /// </summary>
-        public bool IsEmpty => string.IsNullOrEmpty(Serial);
+        public bool IsEmpty => !uint.TryParse(TransportId, out _) && string.IsNullOrEmpty(Serial);
 
         /// <summary>
         /// Creates a new instance of the <see cref="DeviceData"/> class based on
@@ -208,9 +208,9 @@ namespace AdvancedSharpAdbClient.Models
         /// <inheritdoc/>
         public override string ToString()
         {
-            if (string.IsNullOrEmpty(Serial))
+            if (IsEmpty)
             {
-                return $"An empty {GetType()} without {nameof(Serial)}";
+                return $"An empty {GetType()} without {nameof(TransportId)} and {nameof(Serial)}";
             }
 
             StringBuilder builder =
@@ -283,7 +283,7 @@ namespace AdvancedSharpAdbClient.Models
         {
             if (device.IsEmpty)
             {
-                throw new ArgumentOutOfRangeException(nameof(device), "You must specific a serial number for the device");
+                throw new ArgumentOutOfRangeException(nameof(device), "You must specific a transport ID or serial number for the device");
             }
             return ref device;
         }


### PR DESCRIPTION
When connecting devices, prioritize the use of transport_id, which will avoid throwing exception when two devices connected with the same serial